### PR TITLE
Restore image visible again after .destroy()

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -85,7 +85,7 @@
       if (this.opt.imgsrc) {
         this.container.before(this.opt.imgsrc);
         this.container.remove();
-        $(this.opt.imgsrc).removeData('Jcrop');
+        $(this.opt.imgsrc).removeData('Jcrop').show();
       } else {
         // @todo: more elegant destroy() process for non-image containers
         this.container.remove();


### PR DESCRIPTION
When the jcrop_api.destroy() method is called, the original image isn't visible again.
